### PR TITLE
Fix: "Update build.gradle, application.yml"

### DIFF
--- a/ANIS/build.gradle
+++ b/ANIS/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'

--- a/ANIS/src/main/java/com/npt/anis/ANIS/global/config/H2ServerConfiguration.java
+++ b/ANIS/src/main/java/com/npt/anis/ANIS/global/config/H2ServerConfiguration.java
@@ -1,0 +1,20 @@
+package com.npt.anis.ANIS.global.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.h2.tools.Server;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+@Configuration
+public class H2ServerConfiguration {
+    @Bean
+    @ConfigurationProperties("spring.datasource.hikari")
+    public DataSource dataSource() throws SQLException {
+        Server.createTcpServer("-tcp", "-tcpAllowOthers", "-tcpPort", "9092").start();
+        return new HikariDataSource();
+    }
+}

--- a/ANIS/src/main/resources/application.yml
+++ b/ANIS/src/main/resources/application.yml
@@ -1,9 +1,10 @@
 spring:
   datasource:
-    url:  jdbc:h2:tcp://localhost/~/db/H2/anisdb/data;
-    username: sa
-    passward:
-    driver-class-name: org.h2.Driver
+    hikari:
+      jdbc-url: jdbc:h2:tcp://localhost/~/db/H2/anisdb/data;
+      username: sa
+      password:
+      driver-class-name: org.h2.Driver
   h2:
     console:
       enabled: true


### PR DESCRIPTION
우분투 서버로 jar 파일 배포 시, H2 connection refused 이슈 발생함
이를 고치기 위해 h2를 implemetation 시에도 빌드되게 바꿨고, 9092포트에서 tcp를 강제로 열어줬음. 따라서 DB에 접근하려면 기존에 h2-console에 들어가는 방식(localhost:80802)이 아닌, 외부 프로그램에서 DB 소스를 추가하여 tcp로 접속해야함